### PR TITLE
Fix dataset path for training script

### DIFF
--- a/train_models_FO.py
+++ b/train_models_FO.py
@@ -6,10 +6,11 @@ from sklearn.metrics import r2_score, mean_absolute_error
 from sklearn.preprocessing import LabelEncoder
 import pickle
 from datetime import datetime, timedelta
+from pathlib import Path
 
 # Cargar los datos
-file_path = r"C:\Users\iazuaz\PyCharmMiscProject\dotacion_predictor\model_FRONT\data\BBDD_calls_RRSS.xlsx"
-data = pd.read_excel(file_path)
+DATA_PATH = Path(__file__).resolve().parent / "BBDD_calls_RRSS.xlsx"
+data = pd.read_excel(DATA_PATH)
 
 # Limpieza y preprocesamiento
 # Convertir la columna de fecha a datetime


### PR DESCRIPTION
## Summary
- read dataset from repo path rather than a hard-coded path

## Testing
- `python3 verify.py | tee verify_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6883c53b31748328bd3cff1540003389