### PR TITLE
Fix prediction line style

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,7 +160,7 @@ def make_plot(hist, fut, title):
                     line=dict(width=2, color=ACCENT_COLOR),
                     hovertemplate="%{x|%d-%m-%Y}<br>Histórico: %{y}<extra></extra>")
     fig.add_scatter(x=fut["dat"], y=fut["con_pred"], mode="lines", name="Predicción",
-                    line=dict(dash="dash", width=2, color=PRIMARY_BG),
+                    line=dict(width=2, color=PRIMARY_BG),
                     hovertemplate="%{x|%d-%m-%Y}<br>Predicción: %{y}<extra></extra>")
     fig.update_layout(
         title=title,


### PR DESCRIPTION
## Summary
- show the prediction line as a solid line on the plot

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f5d16348832899028d9f7a4c1022