### PR TITLE
Improve mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Pre‑trained models (`*.pkl`) are already included.
 streamlit run app.py
 ```
 
+The dashboard uses responsive styles so the layout looks consistent on
+desktop and mobile browsers (Android and iOS).
+
 ### Training a model
 ```bash
 python train_models_FO.py

--- a/app.py
+++ b/app.py
@@ -70,8 +70,7 @@ col1, col2, col3 = st.columns([1, 2, 1])
 with col2:
     st.image(
         "https://upload.wikimedia.org/wikipedia/commons/2/27/Logo_Ripley_banco_2.png",
-        width=520,
-
+        use_column_width=True,
     )
 st.markdown("---")
 


### PR DESCRIPTION
## Summary
- scale the logo to column width so it fits mobile screens
- mention mobile responsiveness in the README

## Testing
- `python -m py_compile app.py train_models_FO.py`

------
https://chatgpt.com/codex/tasks/task_e_68841e339d4c83288e072ae81b4c2f1c