### PR TITLE
Handle unseen labels in forecast

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,6 +160,10 @@ FEATURES = [
 def forecast(model, hist_df, periods, le, cyb_dates):
     df = hist_df[["dat", "con", "cyb"]].copy().sort_values("dat")
     df["cyb"] = df["cyb"].fillna("NO")
+    # Ensure the label encoder can handle both expected labels
+    if hasattr(le, "classes_"):
+        required = np.array(["NO", "SI"], dtype=object)
+        le.classes_ = np.unique(np.concatenate([le.classes_.astype(object), required]))
     preds = []
     for _ in range(periods):
         next_date = df["dat"].max() + timedelta(days=1)


### PR DESCRIPTION
## Summary
- ensure LabelEncoder can transform "SI" and "NO" during forecasting

## Testing
- `python -m py_compile app.py`
- custom script exercising forecast with unseen label

------
https://chatgpt.com/codex/tasks/task_e_68c41ed9a044832894ae73842d61e62f