### PR TITLE
Align forecast start with data and hold out evaluation set

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,9 +97,10 @@ le = mdata["encoder"]
 r2 = mdata["r2"]
 mae = mdata["mae"]
 rmse = mdata["rmse"]
-last_dt = mdata["last_date"]
 periods = FORECAST_HORIZON[fuente]
 hist_df = load_historical(BASES[fuente])
+# Forecasts should begin the day after the latest entry in the data
+last_dt = hist_df["dat"].max()
 date_options = pd.date_range(last_dt + timedelta(days=1), periods=periods)
 
 # ╭──────────────────────────────────────────────╮

--- a/train_models_FO.py
+++ b/train_models_FO.py
@@ -81,13 +81,15 @@ def train_model(data_path, model_path):
     le = LabelEncoder()
     df["cyb_encoded"] = le.fit_transform(df["cyb"])
 
-    X = df[FEATURES]
-    y = df["con"]
-
-    # Use chronological split for time series
+    # Reserve the last 20% of records for evaluation
     split_index = int(len(df) * 0.8)
-    X_train, X_test = X.iloc[:split_index], X.iloc[split_index:]
-    y_train, y_test = y.iloc[:split_index], y.iloc[split_index:]
+    train_df = df.iloc[:split_index]
+    test_df = df.iloc[split_index:]
+
+    X_train = train_df[FEATURES]
+    y_train = train_df["con"]
+    X_test = test_df[FEATURES]
+    y_test = test_df["con"]
 
     # Hyperparameter tuning with time-series cross-validation
     tscv = TimeSeriesSplit(n_splits=3)


### PR DESCRIPTION
## Summary
- Begin forecast generation from the day after the most recent available data in each model
- Reserve final 20% of records for model accuracy evaluation during training

## Testing
- `python -m py_compile app.py train_models_FO.py`
- `python train_models_FO.py`

------
https://chatgpt.com/codex/tasks/task_e_68c424892dd48328a546b2fb3a111beb